### PR TITLE
Don't spend build time optimizing build-time-only crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ panic = 'abort'
 codegen-units = 1
 incremental = false
 
+[profile.release.build-override]
+opt-level = 0
+
 [workspace]
 members = [
     "gitoxide-core",


### PR DESCRIPTION
Crates used exclusively at build time, such as proc-macro crates and
their dependencies, don't benefit substantially from optimization; they
take far longer to optimize than time saved when running them during the
build. No machine code from these crates will appear in the final
compiled binary.

Use the new profile-overrides mechanism in Rust 1.41
(https://doc.rust-lang.org/cargo/reference/profiles.html#overrides) to
build such crates with opt-level 0.

This substantially speeds up build time.